### PR TITLE
update apt-cache before installing dependencies on debian based distributions

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,4 +1,9 @@
 ---
+- name: Update apt cache before installing dependencies
+  ansible.builtin.apt:
+    update_cache: true
+  when: ansible_distribution == 'Debian'
+
 - name: Install dependencies for debian-based distributions
   ansible.builtin.apt:
     name: " {{ item }}"


### PR DESCRIPTION
##### SUMMARY
update apt-cache before installing dependencies on debian based distributions

fixes #29 

<!--- Describe the change, including rationale and design decisions -->

<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible [core 2.15.7]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/pweisser/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pweisser/ansible-playbooks/venv/lib64/python3.9/site-packages/ansible
  ansible collection location = /home/pweisser/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/pweisser/ansible-playbooks/venv/bin/ansible
  python version = 3.9.18 (main, Sep  7 2023, 00:00:00) [GCC 11.4.1 20230605 (Red Hat 11.4.1-2)] (/home/pweisser/ansible-playbooks/venv/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```


##### ADDITIONAL INFORMATION
This could influence the idempotency of this role - not sure how important it is

To not influence the idempotency `changed_when` could be set to `false`