### PR TITLE
fix(debian): remove old apt repository syntax without signed-by

### DIFF
--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -46,6 +46,15 @@
     state: present
   when: ansible_os_family == 'Debian'
 
+- name: Remove old icinga apt repository without key
+  ansible.builtin.apt_repository:
+    repo: "deb http://packages.icinga.com/{{ ansible_distribution | lower }} icinga-{{ ansible_distribution_release }} main"
+    state: absent
+  when:
+    - ansible_os_family == 'Debian'
+    - (ansible_lsb.id != 'Univention' or ansible_distribution_release != 'stretch')
+  notify: Update package repository
+
 - name: Configure icinga apt repository
   ansible.builtin.apt_repository:
     repo: "{{ icinga2_agent_apt.repo }}"


### PR DESCRIPTION
This fixes duplicate entries in the apt config after https://github.com/adfinis/ansible-role-icinga2_agent/commit/4fa05906eeb4d155eebb3d15eaba1f107ec9f7af