### PR TITLE
feat: add support for Debian 13 with deb822_repository module

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ icinga2_agent_apt:
   repo: "deb http://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main"
   # The icinga signing key
   key: "http://packages.icinga.com/icinga.key"
+
+icinga2_agent_apt_deb822:
+  name: icinga2
+  uris: http://packages.icinga.com/{{ ansible_distribution | lower }}
+  suites: icinga-{{ ansible_distribution_release }
+  components:
+    - main
+  signed_by: http://packages.icinga.com/icinga.key
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,14 @@ icinga2_agent_apt:
     icinga-{{ ansible_distribution_release }} main
   key: http://packages.icinga.com/icinga.key
 
+icinga2_agent_apt_deb822:
+  name: icinga2
+  uris: http://packages.icinga.com/{{ ansible_distribution | lower }}
+  suites: icinga-{{ ansible_distribution_release }}
+  components:
+    - main
+  signed_by: http://packages.icinga.com/icinga.key
+
 # The suse repository and key from Icinga
 icinga2_agent_suse:
   repo: http://packages.icinga.com/SUSE/ICINGA-release.repo

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   description: This role is used to install the icinga2 agent
   company: Adfinis AG
   license: GNU General Public License v3
-  min_ansible_version: 2.0.0
+  min_ansible_version: 2.15.0
   platforms:
     - name: Debian
       versions:

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -8,6 +8,16 @@
     - (ansible_lsb.id != 'Univention' or ansible_distribution_release != 'stretch')
   notify: Update package repository
 
+- name: Remove old icinga apt repository on Debian >= 13
+  ansible.builtin.apt_repository:
+    repo: "{{ icinga2_agent_apt.repo }}"
+    state: absent
+  when:
+    - ansible_os_family == 'Debian'
+    - (ansible_lsb.id != 'Univention' or ansible_distribution_release != 'stretch')
+    - ansible_distribution_major_version | int >=13
+  notify: Update package repository
+
 - name: Install dependencies for debian-based distributions
   ansible.builtin.apt:
     name: " {{ item }}"
@@ -61,7 +71,9 @@
     url: "{{ icinga2_agent_apt.key }}"
     keyring: /usr/share/keyrings/icinga-archive-keyring.gpg
     state: present
-  when: ansible_os_family == 'Debian'
+  when:
+    - ansible_os_family == 'Debian'
+    - ansible_distribution_major_version | int < 13
 
 - name: Configure icinga apt repository
   ansible.builtin.apt_repository:
@@ -70,6 +82,22 @@
   when:
     - ansible_os_family == 'Debian'
     - (ansible_lsb.id != 'Univention' or ansible_distribution_release != 'stretch')
+    - ansible_distribution_major_version | int < 13
+  notify: Update package repository
+
+- name: Configure icinga apt repository for Debian >=13
+  ansible.builtin.deb822_repository:
+    name: "{{ icinga2_agent_apt_deb822.name }}"
+    types: "deb"
+    uris: "{{ icinga2_agent_apt_deb822.uris }}"
+    suites: "{{ icinga2_agent_apt_deb822.suites }}"
+    components: "{{ icinga2_agent_apt_deb822.components }}"
+    signed_by: "{{ icinga2_agent_apt_deb822.signed_by }}"
+    state: present
+  when:
+    - ansible_os_family == 'Debian'
+    - (ansible_lsb.id != 'Univention' or ansible_distribution_release != 'stretch')
+    - ansible_distribution_major_version | int >= 13
   notify: Update package repository
 
 - name: Configure stretch-backports repository

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,7 @@
 
 icinga2_agent_debian_dependencies:
   - gnupg2
+  - python3-debian
 
 icinga2_agent_packages:
   - icinga2


### PR DESCRIPTION
##### SUMMARY
Debian 13 removed the `apt-key`  utility, which causes tasks using the  [`ansible.builtin.apt_key`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html) module to fail.

This PR aims to do the following for systems running debian >= 13:
* Remove repository definitions in the old `.list` format previously instlled
* Install new `.sources` format list for https://packages.icinga.com/ using [deb822_repository](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/deb822_repository_module.html)

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible [core 2.18.1]
  config file = None
  python version = 3.12.3 (main, Apr 10 2024, 05:33:47) [GCC 13.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

